### PR TITLE
fix: ship.js config

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -1,3 +1,4 @@
 module.exports = {
+  buildCommand: () => null,
   publishCommand: () => ":",
 };


### PR DESCRIPTION
build scripts dropped in b904384dd32ae2b89d61c77cb89d2b95f363a0a2