### PR TITLE
fix: unneed default match at fileMatch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:base"],
   "npm": {
-    "fileMatch": ["package(\\.hugo)?\\.json"]
+    "fileMatch": ["package\\.hugo\\.json"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
> fileMatch patterns in the user config are added to the default values and
> do not replace them.

ref: https://docs.renovatebot.com/configuration-options/#filematch